### PR TITLE
Update RFC3986 Uri to align with an alternate public API proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ````php
 $uri = new Uri\Rfc3986\Uri("HTTPS://ex%61mpLE.com:443/foo/../bar/./baz?#fragment");
-$uri->toRawString(); // returns "HTTPS://ex%61mpLE.com:443/foo/../bar/./baz?#fragment"
-$uri->toString();    // returns "https://example.com:443/bar/baz?#fragment"
+$uri->toString(); // returns "HTTPS://ex%61mpLE.com:443/foo/../bar/./baz?#fragment"
+$uri->toNormalizedString();    // returns "https://example.com:443/bar/baz?#fragment"
 
 $url = new Uri\WhatWg\Url("HTTPS://🐘.com:443/foo/../bar/./baz?#fragment");
 echo $url->toAsciiString();   // returns "https://xn--go8h.com/bar/baz?#fragment"

--- a/src/Rfc3986/Uri.php
+++ b/src/Rfc3986/Uri.php
@@ -167,12 +167,12 @@ if (PHP_VERSION_ID < 80500) {
             return new self($uri);
         }
 
-        public function getScheme(): ?string
+        public function getNormalizedScheme(): ?string
         {
             return $this->getComponent(self::TYPE_NORMALIZED, 'scheme');
         }
 
-        public function getRawScheme(): ?string
+        public function getScheme(): ?string
         {
             return $this->getComponent(self::TYPE_RAW, 'scheme');
         }
@@ -183,18 +183,18 @@ if (PHP_VERSION_ID < 80500) {
         public function withScheme(?string $scheme): self
         {
             return match (true) {
-                $scheme === $this->getRawScheme() => $this,
+                $scheme === $this->getScheme() => $this,
                 UriString::isScheme($scheme) => $this->withComponent(['scheme' => $scheme]),
                 default => throw new InvalidUriException('The scheme string component `'.$scheme.'` is an invalid scheme.'),
             };
         }
 
-        public function getUserInfo(): ?string
+        public function getNormalizedUserInfo(): ?string
         {
             return $this->getComponent(self::TYPE_NORMALIZED, 'userInfo');
         }
 
-        public function getRawUserInfo(): ?string
+        public function getUserInfo(): ?string
         {
             return $this->getComponent(self::TYPE_RAW, 'userInfo');
         }
@@ -204,7 +204,7 @@ if (PHP_VERSION_ID < 80500) {
          */
         public function withUserInfo(#[SensitiveParameter] ?string $userInfo): self
         {
-            if ($this->getRawUserInfo() === $userInfo) {
+            if ($this->getUserInfo() === $userInfo) {
                 return $this;
             }
 
@@ -219,32 +219,32 @@ if (PHP_VERSION_ID < 80500) {
             return $this->withComponent(['user' => $user, 'pass' => $password]);
         }
 
-        public function getRawUsername(): ?string
+        public function getUsername(): ?string
         {
             return $this->getComponent(self::TYPE_RAW, 'user');
         }
 
-        public function getUsername(): ?string
+        public function getNormalizedUsername(): ?string
         {
             return $this->getComponent(self::TYPE_NORMALIZED, 'user');
         }
 
-        public function getRawPassword(): ?string
+        public function getPassword(): ?string
         {
             return $this->getComponent(self::TYPE_RAW, 'pass');
         }
 
-        public function getPassword(): ?string
+        public function getNormalizedPassword(): ?string
         {
             return $this->getComponent(self::TYPE_NORMALIZED, 'pass');
         }
 
-        public function getRawHost(): ?string
+        public function getHost(): ?string
         {
             return $this->getComponent(self::TYPE_RAW, 'host');
         }
 
-        public function getHost(): ?string
+        public function getNormalizedHost(): ?string
         {
             return $this->getComponent(self::TYPE_NORMALIZED, 'host');
         }
@@ -255,7 +255,7 @@ if (PHP_VERSION_ID < 80500) {
         public function withHost(?string $host): self
         {
             return match (true) {
-                $host === $this->getRawHost() => $this,
+                $host === $this->getHost() => $this,
                 UriString::isHost($host) => $this->withComponent(['host' => $host]),
                 default => throw new InvalidUriException('The host component value `'.$host.'` is not a valid host.'),
             };
@@ -278,12 +278,12 @@ if (PHP_VERSION_ID < 80500) {
             };
         }
 
-        public function getRawPath(): string
+        public function getPath(): string
         {
             return (string) $this->getComponent(self::TYPE_RAW, 'path');
         }
 
-        public function getPath(): string
+        public function getNormalizedPath(): string
         {
             return (string) $this->getComponent(self::TYPE_NORMALIZED, 'path');
         }
@@ -294,18 +294,18 @@ if (PHP_VERSION_ID < 80500) {
         public function withPath(string $path): self
         {
             return match (true) {
-                $path === $this->getRawPath() => $this,
+                $path === $this->getPath() => $this,
                 Encoder::isPathEncoded($path) => $this->withComponent(['path' => $path]),
                 default => throw new InvalidUriException('The encoded path component `'.$path.'` contains invalid characters.'),
             };
         }
 
-        public function getRawQuery(): ?string
+        public function getQuery(): ?string
         {
             return $this->getComponent(self::TYPE_RAW, 'query');
         }
 
-        public function getQuery(): ?string
+        public function getNormalizedQuery(): ?string
         {
             return $this->getComponent(self::TYPE_NORMALIZED, 'query');
         }
@@ -316,18 +316,18 @@ if (PHP_VERSION_ID < 80500) {
         public function withQuery(?string $query): self
         {
             return match (true) {
-                $query === $this->getRawQuery() => $this,
+                $query === $this->getQuery() => $this,
                 Encoder::isQueryEncoded($query) => $this->withComponent(['query' => $query]),
                 default => throw new InvalidUriException('The encoded query string component `'.$query.'` contains invalid characters.'),
             };
         }
 
-        public function getRawFragment(): ?string
+        public function getFragment(): ?string
         {
             return $this->getComponent(self::TYPE_RAW, 'fragment');
         }
 
-        public function getFragment(): ?string
+        public function getNormalizedFragment(): ?string
         {
             return $this->getComponent(self::TYPE_NORMALIZED, 'fragment');
         }
@@ -338,7 +338,7 @@ if (PHP_VERSION_ID < 80500) {
         public function withFragment(?string $fragment): self
         {
             return match (true) {
-                $fragment === $this->getRawFragment() => $this,
+                $fragment === $this->getFragment() => $this,
                 Encoder::isFragmentEncoded($fragment) => $this->withComponent(['fragment' => $fragment]),
                 default => throw new InvalidUriException('The encoded fragment string component `'.$fragment.'` contains invalid characters.'),
             };
@@ -350,18 +350,18 @@ if (PHP_VERSION_ID < 80500) {
         public function equals(self $uri, UriComparisonMode $uriComparisonMode = UriComparisonMode::ExcludeFragment): bool
         {
             return match (true) {
-                $this->getFragment() === $uri->getFragment(),
+                $this->getNormalizedFragment() === $uri->getNormalizedFragment(),
                 UriComparisonMode::IncludeFragment === $uriComparisonMode => $this->normalizedComponents === $uri->normalizedComponents,
                 default => [...$this->normalizedComponents, ...['fragment' => null]] === [...$uri->normalizedComponents, ...['fragment' => null]],
             };
         }
 
-        public function toRawString(): string
+        public function toString(): string
         {
             return $this->rawUri;
         }
 
-        public function toString(): string
+        public function toNormalizedString(): string
         {
             $this->setNormalizedComponents();
             $this->normalizedUri ??= UriString::build($this->normalizedComponents);
@@ -374,7 +374,7 @@ if (PHP_VERSION_ID < 80500) {
          */
         public function resolve(string $uri): self
         {
-            return new self($uri, $this->toRawString());
+            return new self($uri, $this->toString());
         }
 
         /**
@@ -382,7 +382,7 @@ if (PHP_VERSION_ID < 80500) {
          */
         public function __serialize(): array
         {
-            return [['uri' => $this->toRawString()], []];
+            return [['uri' => $this->toString()], []];
         }
 
         /**

--- a/tests/Rfc3986/UriTest.php
+++ b/tests/Rfc3986/UriTest.php
@@ -32,8 +32,8 @@ final class UriTest extends TestCase
         $uri = Uri::parse('http://example.com');
 
         self::assertInstanceOf(Uri::class, $uri);
-        self::assertSame('http://example.com', $uri->toRawString());
         self::assertSame('http://example.com', $uri->toString());
+        self::assertSame('http://example.com', $uri->toNormalizedString());
     }
 
     #[Test]
@@ -43,7 +43,7 @@ final class UriTest extends TestCase
         $uri = $reflection->newInstanceWithoutConstructor();
 
         $this->expectException(Error::class);
-        $uri->toRawString();
+        $uri->toString();
     }
 
     #[Test]
@@ -119,14 +119,14 @@ final class UriTest extends TestCase
     {
         $uri = new Uri("https://[2001:0db8:0001:0000:0000:0ab9:C0A8:0102]/?foo=bar%26baz%3Dqux");
 
-        self::assertSame('[2001:0db8:0001:0000:0000:0ab9:C0A8:0102]', $uri->getRawHost());
-        self::assertSame('[2001:0db8:0001:0000:0000:0ab9:c0a8:0102]', $uri->getHost());
+        self::assertSame('[2001:0db8:0001:0000:0000:0ab9:C0A8:0102]', $uri->getHost());
+        self::assertSame('[2001:0db8:0001:0000:0000:0ab9:c0a8:0102]', $uri->getNormalizedHost());
 
         self::assertSame('foo=bar%26baz%3Dqux', $uri->getQuery());
-        self::assertSame('foo=bar%26baz%3Dqux', $uri->getRawQuery());
+        self::assertSame('foo=bar%26baz%3Dqux', $uri->getNormalizedQuery());
 
-        self::assertSame('/', $uri->getRawPath());
-        self::assertSame('', $uri->getPath());
+        self::assertSame('/', $uri->getPath());
+        self::assertSame('', $uri->getNormalizedPath());
     }
 
     #[Test]
@@ -134,34 +134,34 @@ final class UriTest extends TestCase
     {
         $uri = new Uri("https://%61pple:p%61ss@b%C3%A9b%C3%A9.be:433/foob%61r?%61bc=%61bc#%61bc");
 
-        self::assertSame('https', $uri->getRawScheme());
         self::assertSame('https', $uri->getScheme());
+        self::assertSame('https', $uri->getNormalizedScheme());
 
-        self::assertSame('%61pple:p%61ss', $uri->getRawUserInfo());
-        self::assertSame('apple:pass', $uri->getUserInfo());
+        self::assertSame('%61pple:p%61ss', $uri->getUserInfo());
+        self::assertSame('apple:pass', $uri->getNormalizedUserInfo());
 
-        self::assertSame('%61pple', $uri->getRawUsername());
-        self::assertSame('apple', $uri->getUsername());
+        self::assertSame('%61pple', $uri->getUsername());
+        self::assertSame('apple', $uri->getNormalizedUsername());
 
-        self::assertSame('p%61ss', $uri->getRawPassword());
-        self::assertSame('pass', $uri->getPassword());
+        self::assertSame('p%61ss', $uri->getPassword());
+        self::assertSame('pass', $uri->getNormalizedPassword());
 
-        self::assertSame('b%C3%A9b%C3%A9.be', $uri->getRawHost());
         self::assertSame('b%C3%A9b%C3%A9.be', $uri->getHost());
+        self::assertSame('b%C3%A9b%C3%A9.be', $uri->getNormalizedHost());
 
         self::assertSame(433, $uri->getPort());
 
-        self::assertSame('/foob%61r', $uri->getRawPath());
-        self::assertSame('/foobar', $uri->getPath());
+        self::assertSame('/foob%61r', $uri->getPath());
+        self::assertSame('/foobar', $uri->getNormalizedPath());
 
-        self::assertSame('%61bc=%61bc', $uri->getRawQuery());
-        self::assertSame('abc=abc', $uri->getQuery());
+        self::assertSame('%61bc=%61bc', $uri->getQuery());
+        self::assertSame('abc=abc', $uri->getNormalizedQuery());
 
-        self::assertSame('%61bc', $uri->getRawFragment());
-        self::assertSame('abc', $uri->getFragment());
+        self::assertSame('%61bc', $uri->getFragment());
+        self::assertSame('abc', $uri->getNormalizedFragment());
 
-        self::assertSame("https://%61pple:p%61ss@b%C3%A9b%C3%A9.be:433/foob%61r?%61bc=%61bc#%61bc", $uri->toRawString());
-        self::assertSame("https://apple:pass@b%C3%A9b%C3%A9.be:433/foobar?abc=abc#abc", $uri->toString());
+        self::assertSame("https://%61pple:p%61ss@b%C3%A9b%C3%A9.be:433/foob%61r?%61bc=%61bc#%61bc", $uri->toString());
+        self::assertSame("https://apple:pass@b%C3%A9b%C3%A9.be:433/foobar?abc=abc#abc", $uri->toNormalizedString());
     }
 
     #[Test]
@@ -169,17 +169,17 @@ final class UriTest extends TestCase
     {
         $uri = new Uri("HTTPS://EXAMPLE.COM/foo/../bar/");
 
-        self::assertSame('HTTPS', $uri->getRawScheme());
-        self::assertSame('https', $uri->getScheme());
+        self::assertSame('HTTPS', $uri->getScheme());
+        self::assertSame('https', $uri->getNormalizedScheme());
 
-        self::assertSame('EXAMPLE.COM', $uri->getRawHost());
-        self::assertSame('example.com', $uri->getHost());
+        self::assertSame('EXAMPLE.COM', $uri->getHost());
+        self::assertSame('example.com', $uri->getNormalizedHost());
 
-        self::assertSame('/foo/../bar/', $uri->getRawPath());
-        self::assertSame('/bar/', $uri->getPath());
+        self::assertSame('/foo/../bar/', $uri->getPath());
+        self::assertSame('/bar/', $uri->getNormalizedPath());
 
-        self::assertSame("HTTPS://EXAMPLE.COM/foo/../bar/", $uri->toRawString());
-        self::assertSame("https://example.com/bar/", $uri->toString());
+        self::assertSame("HTTPS://EXAMPLE.COM/foo/../bar/", $uri->toString());
+        self::assertSame("https://example.com/bar/", $uri->toNormalizedString());
     }
 
     #[Test]
@@ -188,7 +188,7 @@ final class UriTest extends TestCase
         $uri = new Uri("HTTPS://EXAMPLE.COM/foo/../bar/");
         $uriB = unserialize(serialize($uri));
 
-        self::assertSame($uri->toRawString(), $uriB->toRawString());
+        self::assertSame($uri->toString(), $uriB->toString());
         self::assertTrue($uriB->equals($uri));
     }
 
@@ -213,7 +213,7 @@ final class UriTest extends TestCase
     {
         self::assertSame(
             "https://example.com/foo",
-            (new Uri("https://example.com"))->resolve("/foo")->toString()
+            (new Uri("https://example.com"))->resolve("/foo")->toNormalizedString()
         );
     }
 
@@ -231,7 +231,7 @@ final class UriTest extends TestCase
             ->withFragment('abc');
 
         self::assertTrue($uriBis->equals($uri));
-        self::assertNotSame($uri->toRawString(), $uriBis->toRawString());
+        self::assertNotSame($uri->toString(), $uriBis->toString());
         self::assertSame([
             'scheme' => 'https',
             'username' => 'apple',
@@ -249,8 +249,8 @@ final class UriTest extends TestCase
     {
         $uri = new Uri("https://%61pple:p%61ss@ex%61mple.com:433/foob%61r?%61bc=%61bc#%61bc");
 
-        self::assertSame("https://%61pple:p%61ss@ex%61mple.com:433/foob%61r?%61bc=%61bc#%61bc", $uri->toRawString());
-        self::assertSame("https://apple:pass@example.com:433/foobar?abc=abc#abc", $uri->toString());
+        self::assertSame("https://%61pple:p%61ss@ex%61mple.com:433/foob%61r?%61bc=%61bc#%61bc", $uri->toString());
+        self::assertSame("https://apple:pass@example.com:433/foobar?abc=abc#abc", $uri->toNormalizedString());
     }
 
     #[Test]
@@ -258,8 +258,8 @@ final class UriTest extends TestCase
     {
         $uri = new Uri("https://www.b%C3%A9b%C3%A9.be#foobar");
 
-        self::assertSame('www.b%C3%A9b%C3%A9.be', $uri->getRawHost());
         self::assertSame('www.b%C3%A9b%C3%A9.be', $uri->getHost());
+        self::assertSame('www.b%C3%A9b%C3%A9.be', $uri->getNormalizedHost());
     }
 
     #[Test]
@@ -275,7 +275,7 @@ final class UriTest extends TestCase
     {
         $this->expectException(InvalidUriException::class);
 
-        (new Uri(""))->withPath(':/')->toString();
+        (new Uri(""))->withPath(':/')->toNormalizedString();
     }
 
     #[Test]
@@ -284,8 +284,8 @@ final class UriTest extends TestCase
         $uri = new Uri("https://www.b%C3%A9b%C3%A9.be#foobar");
         $newUri = $uri->withScheme('FoO');
 
-        self::assertSame('FoO', $newUri->getRawScheme());
-        self::assertSame('foo', $newUri->getScheme());
+        self::assertSame('FoO', $newUri->getScheme());
+        self::assertSame('foo', $newUri->getNormalizedScheme());
     }
 
     #[Test]
@@ -294,16 +294,16 @@ final class UriTest extends TestCase
         $uri1 = new Uri('http://example.com#foobar');
         $uriWithUser = $uri1->withUserInfo('apple');
 
-        self::assertSame('apple', $uriWithUser->getUserInfo());
-        self::assertSame('apple', $uriWithUser->getUsername());
+        self::assertSame('apple', $uriWithUser->getNormalizedUserInfo());
+        self::assertSame('apple', $uriWithUser->getNormalizedUsername());
+        self::assertNull($uriWithUser->getNormalizedPassword());
         self::assertNull($uriWithUser->getPassword());
-        self::assertNull($uriWithUser->getRawPassword());
 
         $uriWithUserAndPassword = $uriWithUser->withUserInfo('banana:cream');
-        self::assertSame('banana:cream', $uriWithUserAndPassword->getUserInfo());
-        self::assertSame('banana', $uriWithUserAndPassword->getUsername());
-        self::assertSame('cream', $uriWithUserAndPassword->getRawPassword());
+        self::assertSame('banana:cream', $uriWithUserAndPassword->getNormalizedUserInfo());
+        self::assertSame('banana', $uriWithUserAndPassword->getNormalizedUsername());
         self::assertSame('cream', $uriWithUserAndPassword->getPassword());
+        self::assertSame('cream', $uriWithUserAndPassword->getNormalizedPassword());
 
         $uriStripped = $uriWithUserAndPassword->withUserInfo(null);
         self::assertTrue($uriStripped->equals($uri1));
@@ -317,7 +317,7 @@ final class UriTest extends TestCase
 
         self::assertSame(
             "https://[2001:0db8:0001:0000:0000:0ab9:c0a8:0102]?foo=bar%26baz%3Dqux",
-            $uri->toString()
+            $uri->toNormalizedString()
         );
     }
 
@@ -342,7 +342,7 @@ final class UriTest extends TestCase
     {
         self::assertSame(
             'https:example.com',
-            (new Uri("example.com"))->withScheme('https')->toString()
+            (new Uri("example.com"))->withScheme('https')->toNormalizedString()
         );
     }
 
@@ -359,12 +359,12 @@ final class UriTest extends TestCase
     {
         $uri = new Uri("https://[2001:0db8:0001:0000:0000:0ab9:C0A8:0102]/foo/bar%3Fbaz?foo=bar%26baz%3Dqux");
 
-        self::assertSame('[2001:0db8:0001:0000:0000:0ab9:C0A8:0102]', $uri->getRawHost());
-        self::assertSame('[2001:0db8:0001:0000:0000:0ab9:c0a8:0102]', $uri->getHost());
-        self::assertSame('/foo/bar%3Fbaz', $uri->getRawPath());
+        self::assertSame('[2001:0db8:0001:0000:0000:0ab9:C0A8:0102]', $uri->getHost());
+        self::assertSame('[2001:0db8:0001:0000:0000:0ab9:c0a8:0102]', $uri->getNormalizedHost());
         self::assertSame('/foo/bar%3Fbaz', $uri->getPath());
-        self::assertSame('foo=bar%26baz%3Dqux', $uri->getRawQuery());
+        self::assertSame('/foo/bar%3Fbaz', $uri->getNormalizedPath());
         self::assertSame('foo=bar%26baz%3Dqux', $uri->getQuery());
+        self::assertSame('foo=bar%26baz%3Dqux', $uri->getNormalizedQuery());
     }
 
     #[Test]
@@ -372,7 +372,7 @@ final class UriTest extends TestCase
     {
         $uri = new Uri("HTTPS://ex%61mple.com:443/foo/../bar/./baz?#fragment");
 
-        self::assertSame("HTTPS://ex%61mple.com:443/foo/../bar/./baz?#fragment", $uri->toRawString());
-        self::assertSame("https://example.com:443/bar/baz?#fragment", $uri->toString());
+        self::assertSame("HTTPS://ex%61mple.com:443/foo/../bar/./baz?#fragment", $uri->toString());
+        self::assertSame("https://example.com:443/bar/baz?#fragment", $uri->toNormalizedString());
     }
 }


### PR DESCRIPTION
@pmjones Is this the kind of changes you were thinking for the public API ?

In relation to your comment I believe this would solve your issue around assymetric method naming ? If so we could propose this changes ?

I've done the following:

- `(get|to)Raw*` methods => `(get|to)*` method so to be symetric with the wither methods
- current `(get|to)*` methods are renamed `(ge|to)Normalized*` methods

Normalized method name are a bit verbose but I believe this is OK.

