### PR TITLE
Adding softError parameter to Url::resolve method

### DIFF
--- a/src/WhatWg/Url.php
+++ b/src/WhatWg/Url.php
@@ -280,11 +280,13 @@ if (PHP_VERSION_ID < 80500) {
         }
 
         /**
+         * @param array<int, UrlValidationError> $softErrors
+         *
          * @throws InvalidUrlException
          */
-        public function resolve(string $uri): self
+        public function resolve(string $uri, array &$softErrors = []): self
         {
-            return new self($uri, $this->url->href);
+            return new self($uri, $this->url->href, $softErrors);
         }
 
         /**

--- a/tests/WhatWg/UrlTest.php
+++ b/tests/WhatWg/UrlTest.php
@@ -233,4 +233,17 @@ final class UrlTest extends TestCase
         self::assertTrue($urlBis->equals($url));
         self::assertSame($urlBis, $url);
     }
+
+    #[Test]
+    public function it_will_return_soft_errors_when_uri_is_resolved_with_errors(): void
+    {
+        $softErrors = [];
+        $url = new Url("ftp://example.com");
+        $urlBis = $url->resolve("//user:p%61ss@example.org/💩", $softErrors);
+
+        self::assertSame('ftp://user:p%61ss@example.org/%F0%9F%92%A9', $urlBis->toUnicodeString());
+        self::assertNotEmpty($softErrors);
+        self::assertInstanceOf(UrlValidationError::class, $softErrors[0]);
+        self::assertSame(UrlValidationErrorType::InvalidCredentials, $softErrors[0]->type);
+    }
 }


### PR DESCRIPTION
@TimWolla @kocsismate Currently in the RFC the `Url::resolve` method signature the `$softErrors` parameter is missing. But since in the RFC it is stated:

> The `resolve` method is a shorthand for new get_class($uri)(”/foo“, $uri->toRawString()) for RFC 3986, and new get_class($url)(”/foo“, $url->toAsciiString()) for WHATWG URL.

For consistency it should then for WHATWG URL also expose the `$softErrors` parameter.